### PR TITLE
Workflow Bug: AI Response Output Not Interpolated in Comment Step

### DIFF
--- a/workflows/bug-reproduction-check/bug-reproduction-check.yml
+++ b/workflows/bug-reproduction-check/bug-reproduction-check.yml
@@ -58,4 +58,3 @@ jobs:
               body: process.env.AI_RESPONSE
             })
         env:
-          AI_RESPONSE: ${{ steps.analyze-issue.outputs.response }}

--- a/workflows/bug-reproduction-check/bug-reproduction-check.yml
+++ b/workflows/bug-reproduction-check/bug-reproduction-check.yml
@@ -48,8 +48,6 @@ jobs:
       - name: Comment On Issue
         if: contains(join(github.event.issue.labels.*.name, ','), 'bug') && steps.analyze-issue.outputs.response != 'pass'
         uses: actions/github-script@v7
-        env:
-          AI_RESPONSE: steps.analyze-issue.outputs.response
         with:
           script: |
             const issue_number = context.issue.number
@@ -59,3 +57,5 @@ jobs:
               issue_number,
               body: process.env.AI_RESPONSE
             })
+        env:
+          AI_RESPONSE: ${{ steps.analyze-issue.outputs.response }}


### PR DESCRIPTION
This pull request makes a minor adjustment to the environment variable assignment for the "Comment On Issue" step in the `bug-reproduction-check.yml` workflow.

## Summary

### What Was the Issue?

I was setting up a GitHub Actions workflow in my project  to automatically analyze new bug reports using an AI model. The intention was for the workflow to comment on issues that lacked sufficient detail, based on the AI's analysis.

However, I discovered that, instead of posting the AI-generated feedback, the workflow was commenting the literal string `"steps.analyze-issue.outputs.response"` when the check failed. This indicated that the output from the AI step was not being passed correctly to the subsequent comment step.

#### Root Cause

The issue was due to referencing the output of a previous step incorrectly when setting an environment variable:
```yaml
env:
  AI_RESPONSE: steps.analyze-issue.outputs.response
```
This configuration set the environment variable to the literal string, not the evaluated value. In GitHub Actions, I needed to use the expression syntax `${{ ... }}` to interpolate values.

---

### How I Fixed It

I updated the environment variable assignment as follows:
```yaml
env:
  AI_RESPONSE: ${{ steps.analyze-issue.outputs.response }}
```
This ensures that the actual output of the `analyze-issue` step is used, enabling the workflow to post the appropriate AI-generated feedback.

---

## Final (Corrected) Step Example

```yaml
- name: Comment On Issue
  if: contains(join(github.event.issue.labels.*.name, ','), 'bug') && steps.analyze-issue.outputs.response != 'pass'
  uses: actions/github-script@v7
  env:
    AI_RESPONSE: ${{ steps.analyze-issue.outputs.response }}
  with:
    script: |
      const issue_number = context.issue.number
      await github.rest.issues.createComment({
        owner: context.repo.owner,
        repo: context.repo.repo,
        issue_number,
        body: process.env.AI_RESPONSE
      })
```

---

## Outcome

With this fix, my workflow now correctly comments with the AI’s feedback when a bug report is missing required details, making my issue triage process more effective and efficient.
