### PR TITLE
feat: add multilang README translator workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This repository contains a collection of [GitHub Actions](https://github.com/fea
 | [Weekly Issue Summary](/workflows/weekly-issue-summary/weekly-issue-summary.yml) | Opens a new issue weekly summarizing the issues created in the last week. | @phazonoverload |
 | [Bug Reproduction Check](/workflows/bug-reproduction-check/bug-reproduction-check.yml) | Comments with request for better reproduction details, if needed. | @phazonoverload |
 | [Add Merged PR to Changelog](/workflows/add-merged-pr-to-changelog/add-merged-pr-to-changelog.yml) | Appends a summary of a merged pull request to an issue. | @phazonoverload |
+| [Multilang README Translator](/workflows/multilang-readme-translator/translate-readme.yml) | Automatically translates README.md to multiple languages when changes are made. | @FidelusAleksander |
 
 > [!IMPORTANT]  
 > Whenever workflows explicitly accept user input, a malicious actor could open an issue, pull request, or discussion instructing a model to do something you don't want. By carefully writing prompts and providing minimum permissions, you can help mitigate these risks.

--- a/workflows/multilang-readme-translator/translate-readme.yml
+++ b/workflows/multilang-readme-translator/translate-readme.yml
@@ -1,0 +1,92 @@
+name: Translate README
+
+on:
+  push:
+    branches:
+      - main
+      - master
+    paths:
+      - "README.md"
+
+permissions:
+  contents: write
+  pull-requests: write
+  models: read
+
+jobs:
+  translate:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        language: ["spanish", "chinese"]
+        include:
+          - language: "spanish"
+            file: "README.es.md"
+          - language: "chinese"
+            file: "README.zh.md"
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Translate README
+        uses: actions/ai-inference@v2
+        id: translate
+        with:
+          max-tokens: 2000
+          system-prompt: |
+            You are a highly skilled ${{ matrix.language }} translator.
+
+            ## Your Responsibilities
+
+            - Translate the provided text to ${{ matrix.language }}
+            - Detect the source language automatically
+            - Return only the translation, no explanations or notes
+
+            ## Input
+
+            You will receive the text to translate in the user message.
+
+            ## Translation Rules
+            - Preserve the meaning, tone, formatting, structure, and style of the original text
+            - Keep technical terms, code blocks, and code examples in their original form
+            - Keep URLs, file paths, and image references unchanged
+                      
+          prompt-file: README.md
+
+
+      - name: Save translation
+        run: |
+          mkdir -p docs
+          echo "$TRANSLATED_TEXT" | tee docs/${{ matrix.file }}
+        env:
+          TRANSLATED_TEXT: ${{ steps.translate.outputs.response }}
+
+      - name: Upload translation artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.file }}
+          path: docs/${{ matrix.file }}
+
+  create-pr:
+    needs: translate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/download-artifact@v4
+        with:
+          path: docs
+          merge-multiple: true
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v6
+        with:
+          commit-message: "docs: update translations of README"
+          title: "docs: update translations of README"
+          body: |
+            This PR updates all translations of the README:
+
+            Changes were automatically generated using the [ai-inference](https://github.com/actions/ai-inference) action.
+          branch: docs/update-readme-translations
+          add-paths: "docs/README*"
+          delete-branch: true
+          labels: |
+            documentation


### PR DESCRIPTION
Hey! 

I've had GitHub Models in use to translate all of my [website content](https://ghcertified.com/) (500+ files) into multiple languages for quite a bit now, and it's proven to be amazing!

Figured it could be a nice learning sample